### PR TITLE
Upgrade versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Skelton of docker environment with Laravel12, Amazon Linux 2023 and MinIO
 
 ## Containers to be built
 
-- al2023: [Amazon Linux 2023](https://hub.docker.com/layers/library/amazonlinux/2023.7.20250331.0/images/sha256-d2b7c9c18d23a992c5364d51f3ec62f4e5d47b6d0b6dfc35078104d414fe48ba) ([nginx](https://nginx.org/) / [PHP 8.4.5](https://www.php.net/ChangeLog-8.php#8.4.5) / [Laravel 12](https://laravel.com/docs/12.x))
-- mysql: [MySQL Server 8.4.4](https://hub.docker.com/layers/library/mysql/8.4.4/images/sha256-d895a591bdc9fbd228dc75f4859791160f321b839bad18bba44811834143b0c4)
-- mailpit: [axllent/mailpit:v1.24.0](https://hub.docker.com/layers/axllent/mailpit/v1.24.0/images/sha256-15cb8c9cc529859e9f1dd82833a170181bd5650db0a447a05f07b306899a9b2e)
-- minio: [minio/minio:RELEASE.2025-03-12T18-04-18Z](https://hub.docker.com/layers/minio/minio/RELEASE.2025-03-12T18-04-18Z/images/sha256-85f3e4cd1ca92a2711553ab79f222bcd8b75aa2c77a1a0b0ccf80d38e8ab2fe5)
+- al2023: [Amazon Linux 2023](https://hub.docker.com/layers/library/amazonlinux/2023.7.20250331.0/images/sha256-d2b7c9c18d23a992c5364d51f3ec62f4e5d47b6d0b6dfc35078104d414fe48ba) ([nginx](https://nginx.org/) / [PHP 8.4.6](https://www.php.net/ChangeLog-8.php#8.4.6) / [Laravel 12](https://laravel.com/docs/12.x))
+- mysql: [MySQL Server 8.4.5](https://hub.docker.com/layers/library/mysql/8.4.5/images/sha256-dc6acfdfcf111858d8ec72daa23308a54377dc458d10ba4dd9484de2ea3cbc46)
+- mailpit: [axllent/mailpit:v1.24.1](https://hub.docker.com/layers/axllent/mailpit/v1.24.1/images/sha256-29d7973983e738f71fa00886fbb286e95c1c13f41d18e5c99b7b3e4fb1d2087f)
+- minio: [minio/minio:RELEASE.2025-04-08T15-41-24Z](https://hub.docker.com/layers/minio/minio/RELEASE.2025-04-08T15-41-24Z/images/sha256-79f5beef4fe27220c1b55fe8d38a4dc88544870891b871bea6fe113b90256297)
 
 ## Project file structure
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This command performs:
 - `bin/create-project`: creates Laravel 12 project in `html/` on your host.
 - `bin/commands` : lists commands, or show details of commands.
 - `bin/export-data`: exports MySQL data from `mysql` container.
+- `bin/html-cleanup`: removes all files and directories under `html/`.
 - `bin/import-data`: imports MySQL data into `mysql` container.
 - `bin/initial-settings`: performs initial settings on `al2023` container.
 - `bin/mailpit-root`: connects to root shell on `mailpiit` container.

--- a/bin/buildup
+++ b/bin/buildup
@@ -134,7 +134,7 @@ echo
 #     - Storage download test (php artisan minio:get)
 print_bg_green "Running environment tests"
 check_command bin/artisan test
-check_command html/vendor/bin/phpunit --testdox --color tests
+check_command html/vendor/bin/phpunit --testdox --color tests --do-not-cache-result
 echo
 
 print_bg_cyan "All done!" -at-bold

--- a/bin/create-laravel-project
+++ b/bin/create-laravel-project
@@ -1,6 +1,7 @@
 #!/bin/bash
 # @usage create-laravel-project
 # @description creates Laravel 12 project in html/ on your host.
+# @description super user priviledges required.
 # @example create-laravel-project
 
 LARAVEL_VERSION=12
@@ -34,14 +35,9 @@ clean_up_dir () {
         print_bg_red "Operation aborted."
         exit 1
     fi
-    if [ ! -w $1 ]; then
-        print_bg_red "No permission to remove files in [${1}]."
-        print_bg_red "Operation aborted."
-        exit 1
-    fi
     cd $1
     for ENTRY in `ls -a -I '.' -I '..'`; do
-        rm -rf $ENTRY
+        sudo rm -rf $ENTRY
     done
 }
 

--- a/bin/html-cleanup
+++ b/bin/html-cleanup
@@ -1,0 +1,72 @@
+#!/bin/bash
+# @description removes all files and directories under html/.
+# @description super user priviledges required.
+# @usage html-cleanup
+# @example html-cleanup
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+INCLUDE_DIR=$(cd ${SCRIPT_DIR}/../include && pwd)
+DATA_DIR=$(cd ${SCRIPT_DIR}/../html && pwd)
+
+# imports external scripts
+. ${INCLUDE_DIR}/colorizable
+
+is_empty_dir () {
+    ENTRIES=`ls -a -I '.' -I '..' $1`
+    if [ -z "${ENTRIES}" ]; then
+        # empty
+        return 0
+    else
+        # not empty
+        return 1
+    fi
+}
+
+clean_up_dir () {
+    if [ ! -d $1 ]; then
+        print_bg_red "Directory [${1}] not found."
+        print_bg_red "Operation aborted."
+        exit 1
+    fi
+    if [ ! -x $1 ]; then
+        print_bg_red "No permission to enter [${1}]."
+        print_bg_red "Operation aborted."
+        exit 1
+    fi
+    cd $1
+    for ENTRY in `ls -a -I '.' -I '..'`; do
+        sudo rm -rf $ENTRY
+    done
+}
+
+if [ ! -d $DATA_DIR ]; then
+    print_bg_red "Directory [${DATA_DIR}] not found."
+    print_bg_red "Operation aborted."
+    exit 1
+fi
+
+is_empty_dir $DATA_DIR
+if [ $? -eq 0 ]; then
+    print_green "Directory [${DATA_DIR}] is empty."
+    exit
+fi
+
+print_yellow "Directory [${DATA_DIR}] is not empty."
+CAN_CLEAN_UP=""
+while [[ ! $CAN_CLEAN_UP =~ ^[ny]$ ]]; do
+    echo -n "Are you sure you want to delete whole data? [y/n]:"
+    read CAN_CLEAN_UP
+done
+if [ $CAN_CLEAN_UP = "n" ]; then
+    print_bg_red "Operation aborted."
+    exit 1
+fi
+
+print_cyan "Cleaning up directory [${DATA_DIR}]..."
+clean_up_dir $DATA_DIR
+if [ $? -ne 0 ]; then
+    print_bg_red "Operation failed!"
+    exit 1
+fi
+
+print_green "Completed!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     networks:
       - skynet
   minio:
-    image: minio/minio:RELEASE.2025-03-12T18-04-18Z
+    image: minio/minio:RELEASE.2025-04-08T15-41-24Z
     ports:
         - '9000:9000'
         - '9001:9001'

--- a/docker/al2023/Dockerfile
+++ b/docker/al2023/Dockerfile
@@ -50,7 +50,7 @@ RUN dnf install \
     -y
 
 WORKDIR /root
-ARG php_version="8.4.5"
+ARG php_version="8.4.6"
 RUN curl https://www.php.net/distributions/php-${php_version}.tar.gz -o php-${php_version}.tar.gz \
     && tar xvfz php-${php_version}.tar.gz \
     && cd php-${php_version} \

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/layers/library/mysql/8.4.4/images/sha256-d895a591bdc9fbd228dc75f4859791160f321b839bad18bba44811834143b0c4
-FROM mysql:8.4.4
+FROM mysql:8.4.5
 
 COPY ./my.cnf /etc/mysql/conf.d/my.cnf
 COPY ./db-access.cnf /root/db-access.cnf


### PR DESCRIPTION
This PR:

- Upgrades PHP version 8.4.5 to 8.4.6.
- Upgrades MySQL version 8.4.4 to 8.4.5
- Upgrades MinIO Image RELEASE.2025-03-12T18-04-18Z to RELEASE.2025-04-08T15-41-24Z
- Adds `bin/html-cleanup` command.
- Adds `--do-not-cache-result` option for phpunit.
- Adds `sudo` to `bin/create-laravel-project`.
