### PR TITLE
Fix: bin/minio-cleanup does not create a bucket when data/ is empty.

### DIFF
--- a/bin/minio-cleanup
+++ b/bin/minio-cleanup
@@ -53,7 +53,6 @@ fi
 ENTRIES=`ls -a -I '.' -I '..' -I '.gitignore' ${DATA_DIR}`
 if [ -z "${ENTRIES}" ]; then
     print_green "Directory [${DATA_DIR}] is empty."
-    exit;
 else
     print_yellow "Directory [${DATA_DIR}] is not empty."
     echo "Cleaning up [${DATA_DIR}]..."


### PR DESCRIPTION
This PR fixes a bug:

- Fix: `bin/minio-cleanup` does not create a bucket when `docker/minio/data/` is empty, and this causes the test failed.